### PR TITLE
INTYGFV-11408: Setting focus of elements to browser default

### DIFF
--- a/web/src/main/webapp/app/components/miHelpNavigationMenu/miHelpNavigationMenu.directive.scss
+++ b/web/src/main/webapp/app/components/miHelpNavigationMenu/miHelpNavigationMenu.directive.scss
@@ -25,8 +25,12 @@ mi-help-navigation-menu {
 
         &:hover {
           color: $mi-link-color;
-          background-color: $nav-pills-active-link-hover-bg;
+          background-color: transparent;
           text-decoration: underline;
+        }
+
+        &:focus {
+          background-color: transparent;
         }
       }
 

--- a/web/src/main/webapp/app/components/miHelpNavigationMenu/miHelpNavigationMenu.directive.scss
+++ b/web/src/main/webapp/app/components/miHelpNavigationMenu/miHelpNavigationMenu.directive.scss
@@ -25,12 +25,12 @@ mi-help-navigation-menu {
 
         &:hover {
           color: $mi-link-color;
-          background-color: transparent;
+          background-color: $nav-pills-active-link-hover-bg;
           text-decoration: underline;
         }
 
         &:focus {
-          background-color: transparent;
+          background-color: $nav-pills-active-link-hover-bg;
         }
       }
 

--- a/web/src/main/webapp/app/mixins/_bootstrap-override.scss
+++ b/web/src/main/webapp/app/mixins/_bootstrap-override.scss
@@ -64,16 +64,25 @@ h2 {
 }
 
 .btn-primary {
+  &:focus {
+    background-color: $mi-button-bg;
+  }
   //For now - we have same style for all interaction states of buttons.
-  &:hover, &:focus, &:active, &:focus:active {
+  &:hover, &:active, &:focus:active {
     color: $mi-button-bg;
     background-color: $mi-button-primary;
     border-color: $mi-button-primary;
   }
+
 }
 
+
 .btn-secondary {
-  &:hover, &:focus, &:active, &:focus:active {
+  &:focus {
+    background-color: $mi-button-bg;
+  }
+
+  &:hover, &:active, &:focus:active {
     color: $mi-button-bg;
     background-color: $mi-button-secondary;
     border-color: $mi-button-secondary;
@@ -81,7 +90,11 @@ h2 {
 }
 
 .btn-third {
-  &:hover, &:focus, &:active, &:focus:active {
+  &:focus {
+    background-color: $mi-button-bg;
+  }
+
+  &:hover, &:active, &:focus:active {
     color: $mi-button-bg;
     background-color: $mi-button-third;
     border-color: $mi-button-third;
@@ -154,5 +167,11 @@ h2 {
 @media all and (max-width: 728px) {
   [uib-popover-popup].popover, [uib-popover-html-popup].popover, [uib-popover-template-popup].popover {
     display: none !important;
+  }
+}
+
+.navbar-toggle {
+  &:focus {
+    appearance: none;
   }
 }

--- a/web/src/main/webapp/app/mixins/_bootstrap-override.scss
+++ b/web/src/main/webapp/app/mixins/_bootstrap-override.scss
@@ -76,7 +76,6 @@ h2 {
 
 }
 
-
 .btn-secondary {
   &:focus {
     background-color: $mi-button-bg;
@@ -167,11 +166,5 @@ h2 {
 @media all and (max-width: 728px) {
   [uib-popover-popup].popover, [uib-popover-html-popup].popover, [uib-popover-template-popup].popover {
     display: none !important;
-  }
-}
-
-.navbar-toggle {
-  &:focus {
-    appearance: none;
   }
 }

--- a/web/src/main/webapp/app/mixins/_bootstrap-override.scss
+++ b/web/src/main/webapp/app/mixins/_bootstrap-override.scss
@@ -67,7 +67,7 @@ h2 {
   &:focus {
     background-color: $mi-button-bg;
   }
-  //For now - we have same style for all interaction states of buttons.
+
   &:hover, &:active, &:focus:active {
     color: $mi-button-bg;
     background-color: $mi-button-primary;


### PR DESCRIPTION
Changed the focus of elements to have only the default focus outline (top) instead of, as before, both the focus outline and the hover green background-color (bottom). Imgs are from Chrome.
![focus_new](https://user-images.githubusercontent.com/55154460/96189063-1d5eae80-0f40-11eb-8ea2-e072cb916bb2.png)
![focus_old](https://user-images.githubusercontent.com/55154460/96189071-20599f00-0f40-11eb-9591-9c5293ef258f.png)

 