### PR TITLE
INTYGFV-15983: Changed subQuestionLevel so that it displays h4 instead of h5.

### DIFF
--- a/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/FormattedQuestionConverter.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/FormattedQuestionConverter.java
@@ -63,7 +63,7 @@ public class FormattedQuestionConverter {
   }
 
   private String subQuestionLabel(String label) {
-    return HTMLTextFactory.h5(label);
+    return HTMLTextFactory.h4(label);
   }
 
   private String value(CertificateQuestionValue value) {

--- a/app/src/test/java/se/inera/intyg/minaintyg/certificate/service/FormattedQuestionConverterTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/certificate/service/FormattedQuestionConverterTest.java
@@ -118,7 +118,7 @@ class FormattedQuestionConverterTest {
     final var result = formattedQuestionConverter.convert(completeQuestion);
 
     assertEquals(
-        "<h3 className=\"ids-heading-3\">Complete title</h3><h4 className=\"ids-heading-4\">Complete label</h4><p>Complete text</p><h4 className=\"ids-heading-4\">Title</h4><h5 className=\"ids-heading-5\">Label</h5><p>element 1</p>",
+        "<h3 className=\"ids-heading-3\">Complete title</h3><h4 className=\"ids-heading-4\">Complete label</h4><p>Complete text</p><h4 className=\"ids-heading-4\">Title</h4><h4 className=\"ids-heading-4\">Label</h4><p>element 1</p>",
         result);
   }
 


### PR DESCRIPTION
Reason for this change is related to how h5 are beeing displayed in frontend https://design.inera.se/?path=/docs/layout-typography--semantics-and-style-separation#headings