### PR TITLE
INTYGFV-16098: Added texts to get certificate response

### DIFF
--- a/app/src/main/java/se/inera/intyg/minaintyg/certificate/CertificateController.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/certificate/CertificateController.java
@@ -65,6 +65,7 @@ public class CertificateController {
         .builder()
         .certificate(response.getCertificate())
         .availableFunctions(response.getAvailableFunctions())
+        .texts(response.getTexts())
         .build();
   }
 

--- a/app/src/main/java/se/inera/intyg/minaintyg/certificate/dto/CertificateResponseDTO.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/certificate/dto/CertificateResponseDTO.java
@@ -1,10 +1,12 @@
 package se.inera.intyg.minaintyg.certificate.dto;
 
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Value;
 import se.inera.intyg.minaintyg.certificate.service.dto.FormattedCertificate;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.common.AvailableFunction;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.common.CertificateTextType;
 
 @Value
 @Builder
@@ -12,4 +14,5 @@ public class CertificateResponseDTO {
 
   FormattedCertificate certificate;
   List<AvailableFunction> availableFunctions;
+  Map<CertificateTextType, String> texts;
 }

--- a/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverter.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverter.java
@@ -13,19 +13,19 @@ import se.inera.intyg.minaintyg.util.html.HTMLTextFactory;
 @RequiredArgsConstructor
 public class CertificateTextConverter {
 
-  public String convert(CertificateText text) {
-    if (text.getLinks() == null || text.getLinks().isEmpty()) {
-      return text.getText();
+  public String convert(CertificateText certificateText) {
+    if (certificateText.getLinks() == null || certificateText.getLinks().isEmpty()) {
+      return certificateText.getText();
     }
 
-    final var linkIds = getLinkIds(text);
-    final var formattedLinks = getFormattedLinks(text);
+    final var linkIds = getLinkIds(certificateText);
+    final var formattedLinks = getFormattedLinks(certificateText);
 
-    return StringUtils.replaceEach(text.getText(), linkIds, formattedLinks);
+    return StringUtils.replaceEach(certificateText.getText(), linkIds, formattedLinks);
   }
 
-  private String[] getFormattedLinks(CertificateText text) {
-    return toArray(text.getLinks(), this::formatLink);
+  private String[] getFormattedLinks(CertificateText certificateText) {
+    return toArray(certificateText.getLinks(), this::formatLink);
   }
 
   private String[] getLinkIds(CertificateText text) {

--- a/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverter.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverter.java
@@ -1,0 +1,49 @@
+package se.inera.intyg.minaintyg.certificate.service;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateLink;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateText;
+import se.inera.intyg.minaintyg.util.html.HTMLTextFactory;
+
+@Service
+@RequiredArgsConstructor
+public class CertificateTextConverter {
+
+  public static final String REGEX = "[^}]*+";
+
+  public String convert(CertificateText text) {
+    if (hasLinks(text.getText())) {
+      return formatText(text);
+    }
+
+    return text.getText();
+  }
+
+  private boolean hasLinks(String text) {
+    return text.split(REGEX).length > 1;
+  }
+
+  private String formatText(CertificateText text) {
+    final var linkIds = text.getLinks()
+        .stream()
+        .map(this::formatLinkId)
+        .toArray(String[]::new);
+
+    final var formattedLinks = text.getLinks()
+        .stream()
+        .map(this::formatLink)
+        .toArray(String[]::new);
+
+    return StringUtils.replaceEach(text.getText(), linkIds, formattedLinks);
+  }
+
+  private String formatLink(CertificateLink link) {
+    return HTMLTextFactory.link(link.getUrl(), link.getName());
+  }
+
+  private String formatLinkId(CertificateLink link) {
+    return "{" + link.getId() + "}";
+  }
+}

--- a/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverter.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverter.java
@@ -1,5 +1,7 @@
 package se.inera.intyg.minaintyg.certificate.service;
 
+import java.util.List;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
@@ -11,32 +13,30 @@ import se.inera.intyg.minaintyg.util.html.HTMLTextFactory;
 @RequiredArgsConstructor
 public class CertificateTextConverter {
 
-  public static final String REGEX = "[^}]*+";
-
   public String convert(CertificateText text) {
-    if (hasLinks(text.getText())) {
-      return formatText(text);
+    if (text.getLinks() == null || text.getLinks().isEmpty()) {
+      return text.getText();
     }
 
-    return text.getText();
-  }
-
-  private boolean hasLinks(String text) {
-    return text.split(REGEX).length > 1;
-  }
-
-  private String formatText(CertificateText text) {
-    final var linkIds = text.getLinks()
-        .stream()
-        .map(this::formatLinkId)
-        .toArray(String[]::new);
-
-    final var formattedLinks = text.getLinks()
-        .stream()
-        .map(this::formatLink)
-        .toArray(String[]::new);
+    final var linkIds = getLinkIds(text);
+    final var formattedLinks = getFormattedLinks(text);
 
     return StringUtils.replaceEach(text.getText(), linkIds, formattedLinks);
+  }
+
+  private String[] getFormattedLinks(CertificateText text) {
+    return toArray(text.getLinks(), this::formatLink);
+  }
+
+  private String[] getLinkIds(CertificateText text) {
+    return toArray(text.getLinks(), this::formatLinkId);
+  }
+
+  private String[] toArray(List<CertificateLink> links,
+      Function<CertificateLink, String> formatter) {
+    return links.stream()
+        .map(formatter)
+        .toArray(String[]::new);
   }
 
   private String formatLink(CertificateLink link) {

--- a/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/GetCertificateService.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/GetCertificateService.java
@@ -1,11 +1,13 @@
 package se.inera.intyg.minaintyg.certificate.service;
 
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import se.inera.intyg.minaintyg.certificate.service.dto.GetCertificateRequest;
 import se.inera.intyg.minaintyg.certificate.service.dto.GetCertificateResponse;
 import se.inera.intyg.minaintyg.integration.api.certificate.GetCertificateIntegrationRequest;
 import se.inera.intyg.minaintyg.integration.api.certificate.GetCertificateIntegrationService;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateText;
 import se.inera.intyg.minaintyg.logging.service.MonitoringLogService;
 
 @Service
@@ -15,6 +17,7 @@ public class GetCertificateService {
   private final GetCertificateIntegrationService getCertificateIntegrationService;
   private final MonitoringLogService monitoringLogService;
   private final FormattedCertificateConverter formattedCertificateConverter;
+  private final CertificateTextConverter certificateTextConverter;
 
   public GetCertificateResponse get(GetCertificateRequest request) {
 
@@ -33,6 +36,11 @@ public class GetCertificateService {
     return GetCertificateResponse.builder()
         .certificate(formattedCertificateConverter.convert(response.getCertificate()))
         .availableFunctions(response.getAvailableFunctions())
+        .texts(
+            response.getTexts().stream()
+                .collect(
+                    Collectors.toMap(CertificateText::getType, certificateTextConverter::convert))
+        )
         .build();
   }
 }

--- a/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/dto/GetCertificateResponse.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/certificate/service/dto/GetCertificateResponse.java
@@ -1,9 +1,11 @@
 package se.inera.intyg.minaintyg.certificate.service.dto;
 
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Value;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.common.AvailableFunction;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.common.CertificateTextType;
 
 @Value
 @Builder
@@ -11,4 +13,5 @@ public class GetCertificateResponse {
 
   FormattedCertificate certificate;
   List<AvailableFunction> availableFunctions;
+  Map<CertificateTextType, String> texts;
 }

--- a/app/src/main/java/se/inera/intyg/minaintyg/util/html/HTMLFactory.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/util/html/HTMLFactory.java
@@ -1,5 +1,8 @@
 package se.inera.intyg.minaintyg.util.html;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 public class HTMLFactory {
 
   private static final String START_FIRST_TAG = "<";
@@ -18,31 +21,31 @@ public class HTMLFactory {
   }
 
   public static String tag(String tagName, String className, String value) {
-    return tag(tagName, className, value, null, null);
+    return tag(tagName, className, value, null);
   }
 
-  public static String tag(String tagName, String className, String value, String attributeName,
-      String attributeValue) {
+  public static String tag(String tagName, String className, String value,
+      Map<String, String> attributes) {
     if (value == null || tagName == null || tagName.isEmpty()) {
       return "";
     }
+
+    final var formattedAttributes = formatAttributes(attributes);
     final var text = convertLineSeparatorsIfPresent(value);
-    return startTag(tagName, className, attributeName, attributeValue) + text + endTag(tagName);
+
+    return startTag(tagName, className, formattedAttributes) + text + endTag(tagName);
   }
 
   public static String tag(String tagName, String value) {
-    return tag(tagName, null, value, null, null);
+    return tag(tagName, null, value, null);
   }
 
-  private static String startTag(String tagName, String className, String attributeName,
-      String attributeValue) {
-    
-    final var attribute = buildTag(attributeName, attributeValue);
+  private static String startTag(String tagName, String className, String attributes) {
     final var classNameTag = buildTag(CLASSNAME, className);
 
     return START_FIRST_TAG + tagName
         + classNameTag
-        + attribute
+        + attributes
         + START_SECOND_TAG;
 
   }
@@ -62,5 +65,15 @@ public class HTMLFactory {
 
   private static String convertLineSeparators(String value) {
     return value.replace(LINE_SEPARATOR, BR_TAG);
+  }
+
+  private static String formatAttributes(Map<String, String> attributes) {
+    if (attributes == null) {
+      return "";
+    }
+
+    return attributes.entrySet().stream()
+        .map(entry -> buildTag(entry.getKey(), entry.getValue()))
+        .collect(Collectors.joining());
   }
 }

--- a/app/src/main/java/se/inera/intyg/minaintyg/util/html/HTMLFactory.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/util/html/HTMLFactory.java
@@ -18,11 +18,42 @@ public class HTMLFactory {
   }
 
   public static String tag(String tagName, String className, String value) {
+    return tag(tagName, className, value, null, null);
+  }
+
+  public static String tag(String tagName, String className, String value, String attributeName,
+      String attributeValue) {
     if (value == null || tagName == null || tagName.isEmpty()) {
       return "";
     }
     final var text = convertLineSeparatorsIfPresent(value);
-    return startTag(tagName, className) + text + endTag(tagName);
+    return startTag(tagName, className, attributeName, attributeValue) + text + endTag(tagName);
+  }
+
+  public static String tag(String tagName, String value) {
+    return tag(tagName, null, value, null, null);
+  }
+
+  private static String startTag(String tagName, String className, String attributeName,
+      String attributeValue) {
+    
+    final var attribute = buildTag(attributeName, attributeValue);
+    final var classNameTag = buildTag(CLASSNAME, className);
+
+    return START_FIRST_TAG + tagName
+        + classNameTag
+        + attribute
+        + START_SECOND_TAG;
+
+  }
+
+  private static String buildTag(String name, String value) {
+    return name == null || value == null ? "" :
+        SPACE + name + START_ATTRIBUTE_TAG + value + END_ATTRIBUTE_TAG;
+  }
+
+  private static String endTag(String tagName) {
+    return END_FIRST_TAG + tagName + END_SECOND_TAG;
   }
 
   private static String convertLineSeparatorsIfPresent(String value) {
@@ -31,24 +62,5 @@ public class HTMLFactory {
 
   private static String convertLineSeparators(String value) {
     return value.replace(LINE_SEPARATOR, BR_TAG);
-  }
-
-  public static String tag(String tagName, String value) {
-    return tag(tagName, null, value);
-  }
-
-
-  private static String startTag(String tagName, String className) {
-    if (className != null) {
-      return START_FIRST_TAG + tagName + SPACE
-          + CLASSNAME + START_ATTRIBUTE_TAG + className + END_ATTRIBUTE_TAG
-          + START_SECOND_TAG;
-    }
-
-    return START_FIRST_TAG + tagName + START_SECOND_TAG;
-  }
-
-  private static String endTag(String tagName) {
-    return END_FIRST_TAG + tagName + END_SECOND_TAG;
   }
 }

--- a/app/src/main/java/se/inera/intyg/minaintyg/util/html/HTMLTextFactory.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/util/html/HTMLTextFactory.java
@@ -8,6 +8,7 @@ public class HTMLTextFactory {
   private static final String IDS_HEADING_3 = "ids-heading-3";
   private static final String IDS_HEADING_4 = "ids-heading-4";
   private static final String IDS_HEADING_5 = "ids-heading-5";
+
   private HTMLTextFactory() {
     throw new IllegalStateException("Utility class");
   }
@@ -30,6 +31,10 @@ public class HTMLTextFactory {
 
   public static String p(String value) {
     return tag("p", value);
+  }
+
+  public static String link(String url, String name) {
+    return tag("IDSLink", null, name, "href", url);
   }
 
 }

--- a/app/src/main/java/se/inera/intyg/minaintyg/util/html/HTMLTextFactory.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/util/html/HTMLTextFactory.java
@@ -2,6 +2,8 @@ package se.inera.intyg.minaintyg.util.html;
 
 import static se.inera.intyg.minaintyg.util.html.HTMLFactory.tag;
 
+import java.util.HashMap;
+
 public class HTMLTextFactory {
 
   private static final String IDS_HEADING_2 = "ids-heading-2";
@@ -34,7 +36,11 @@ public class HTMLTextFactory {
   }
 
   public static String link(String url, String name) {
-    return tag("IDSLink", null, name, "href", url);
+    final var attributes = new HashMap<String, String>();
+    attributes.put("href", url);
+    attributes.put("target", "_blank");
+
+    return tag("a", null, name, attributes);
   }
 
 }

--- a/app/src/test/java/se/inera/intyg/minaintyg/certificate/CertificateControllerTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/certificate/CertificateControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateLis
 import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateMetadata;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.common.AvailableFunction;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.common.CertificateStatusType;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.common.CertificateTextType;
 
 @ExtendWith(MockitoExtension.class)
 class CertificateControllerTest {
@@ -163,6 +165,7 @@ class CertificateControllerTest {
                 .build()
         )
         .availableFunctions(List.of(AvailableFunction.builder().build()))
+        .texts(Map.of(CertificateTextType.DESCRIPTION, "TEXT"))
         .build();
 
     @BeforeEach
@@ -196,6 +199,13 @@ class CertificateControllerTest {
         final var response = certificateController.getCertificate(CERTIFICATE_ID);
 
         assertEquals(expectedResponse.getAvailableFunctions(), response.getAvailableFunctions());
+      }
+
+      @Test
+      void shouldSetTexts() {
+        final var response = certificateController.getCertificate(CERTIFICATE_ID);
+
+        assertEquals(expectedResponse.getTexts(), response.getTexts());
       }
     }
   }

--- a/app/src/test/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverterTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverterTest.java
@@ -62,7 +62,7 @@ class CertificateTextConverterTest {
     final var response = certificateTextConverter.convert(TEXT_WITH_LINK);
 
     assertEquals(
-        "Text <IDSLink href=\"https://test.com\">Länknamn</IDSLink> with link",
+        "Text <a href=\"https://test.com\" target=\"_blank\">Länknamn</a> with link",
         response);
   }
 
@@ -71,7 +71,7 @@ class CertificateTextConverterTest {
     final var response = certificateTextConverter.convert(TEXT_WITH_LINKS);
 
     assertEquals(
-        "Text <IDSLink href=\"https://test.com\">Länknamn</IDSLink> with links <IDSLink href=\"https://test2.com\">Länknamn 2</IDSLink>",
+        "Text <a href=\"https://test.com\" target=\"_blank\">Länknamn</a> with links <a href=\"https://test2.com\" target=\"_blank\">Länknamn 2</a>",
         response);
   }
 
@@ -80,7 +80,7 @@ class CertificateTextConverterTest {
     final var response = certificateTextConverter.convert(TEXT_WITH_SAME_LINKS);
 
     assertEquals(
-        "Text <IDSLink href=\"https://test.com\">Länknamn</IDSLink> with link <IDSLink href=\"https://test.com\">Länknamn</IDSLink>",
+        "Text <a href=\"https://test.com\" target=\"_blank\">Länknamn</a> with link <a href=\"https://test.com\" target=\"_blank\">Länknamn</a>",
         response);
   }
 }

--- a/app/src/test/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverterTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverterTest.java
@@ -1,0 +1,67 @@
+package se.inera.intyg.minaintyg.certificate.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateLink;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateText;
+
+@ExtendWith(MockitoExtension.class)
+class CertificateTextConverterTest {
+
+  private static final CertificateText TEXT_NO_LINKS = CertificateText.builder()
+      .text("TEXT_NO_LINKS").build();
+  private static final CertificateText TEXT_WITH_LINK = CertificateText
+      .builder()
+      .text("Text {L1} with link")
+      .links(
+          List.of(
+              CertificateLink.builder().id("L1").url("https://test.com").name("Länknamn").build()
+          )
+      )
+      .build();
+
+  private static final CertificateText TEXT_WITH_LINKS = CertificateText
+      .builder()
+      .text("Text {L1} with links {L2}")
+      .links(
+          List.of(
+              CertificateLink.builder().id("L1").url("https://test.com").name("Länknamn").build(),
+              CertificateLink.builder().id("L2").url("https://test2.com").name("Länknamn 2").build()
+          )
+      )
+      .build();
+
+
+  @InjectMocks
+  private CertificateTextConverter certificateTextConverter;
+
+  @Test
+  void shouldReturnTextWithoutLink() {
+    final var response = certificateTextConverter.convert(TEXT_NO_LINKS);
+
+    assertEquals(TEXT_NO_LINKS.getText(), response);
+  }
+
+  @Test
+  void shouldReturnTextWithFormattedLink() {
+    final var response = certificateTextConverter.convert(TEXT_WITH_LINK);
+
+    assertEquals(
+        "Text <IDSLink href=\"https://test.com\">Länknamn</IDSLink> with link",
+        response);
+  }
+
+  @Test
+  void shouldReturnTextWithFormattedLinks() {
+    final var response = certificateTextConverter.convert(TEXT_WITH_LINKS);
+
+    assertEquals(
+        "Text <IDSLink href=\"https://test.com\">Länknamn</IDSLink> with links <IDSLink href=\"https://test2.com\">Länknamn 2</IDSLink>",
+        response);
+  }
+}

--- a/app/src/test/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverterTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/certificate/service/CertificateTextConverterTest.java
@@ -25,6 +25,16 @@ class CertificateTextConverterTest {
       )
       .build();
 
+  private static final CertificateText TEXT_WITH_SAME_LINKS = CertificateText
+      .builder()
+      .text("Text {L1} with link {L1}")
+      .links(
+          List.of(
+              CertificateLink.builder().id("L1").url("https://test.com").name("Länknamn").build()
+          )
+      )
+      .build();
+
   private static final CertificateText TEXT_WITH_LINKS = CertificateText
       .builder()
       .text("Text {L1} with links {L2}")
@@ -62,6 +72,15 @@ class CertificateTextConverterTest {
 
     assertEquals(
         "Text <IDSLink href=\"https://test.com\">Länknamn</IDSLink> with links <IDSLink href=\"https://test2.com\">Länknamn 2</IDSLink>",
+        response);
+  }
+
+  @Test
+  void shouldReturnTextWithFormattedLinkTwice() {
+    final var response = certificateTextConverter.convert(TEXT_WITH_SAME_LINKS);
+
+    assertEquals(
+        "Text <IDSLink href=\"https://test.com\">Länknamn</IDSLink> with link <IDSLink href=\"https://test.com\">Länknamn</IDSLink>",
         response);
   }
 }

--- a/app/src/test/java/se/inera/intyg/minaintyg/util/html/HTMLFactoryTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/util/html/HTMLFactoryTest.java
@@ -36,6 +36,13 @@ class HTMLFactoryTest {
   }
 
   @Test
+  void shouldReturnCorrectTagWithAttribute() {
+    final var result = HTMLFactory.tag("tag", null, "Value", "attribute", "attributeValue");
+
+    assertEquals("<tag attribute=\"attributeValue\">Value</tag>", result);
+  }
+
+  @Test
   void shouldConvertLineSeparatorsToBr() {
     final var result = HTMLFactory.tag("tag", "Value\nValue");
 
@@ -57,6 +64,13 @@ class HTMLFactoryTest {
       final var result = HTMLFactory.tag("tag", "class", "Value");
 
       assertEquals("<tag className=\"class\">Value</tag>", result);
+    }
+
+    @Test
+    void shouldReturnCorrectTagWithAttribute() {
+      final var result = HTMLFactory.tag("tag", "class", "Value", "attribute", "attributeValue");
+
+      assertEquals("<tag className=\"class\" attribute=\"attributeValue\">Value</tag>", result);
     }
 
     @Test

--- a/app/src/test/java/se/inera/intyg/minaintyg/util/html/HTMLFactoryTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/util/html/HTMLFactoryTest.java
@@ -2,6 +2,7 @@ package se.inera.intyg.minaintyg.util.html;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.HashMap;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -37,9 +38,12 @@ class HTMLFactoryTest {
 
   @Test
   void shouldReturnCorrectTagWithAttribute() {
-    final var result = HTMLFactory.tag("tag", null, "Value", "attribute", "attributeValue");
+    final var attributes = new HashMap<String, String>();
+    attributes.put("attribute", "attributeValue");
+    attributes.put("href", "url");
+    final var result = HTMLFactory.tag("tag", null, "Value", attributes);
 
-    assertEquals("<tag attribute=\"attributeValue\">Value</tag>", result);
+    assertEquals("<tag attribute=\"attributeValue\" href=\"url\">Value</tag>", result);
   }
 
   @Test
@@ -67,10 +71,15 @@ class HTMLFactoryTest {
     }
 
     @Test
-    void shouldReturnCorrectTagWithAttribute() {
-      final var result = HTMLFactory.tag("tag", "class", "Value", "attribute", "attributeValue");
+    void shouldReturnCorrectTagWithAttributes() {
+      final var attributes = new HashMap<String, String>();
+      attributes.put("attribute", "attributeValue");
+      attributes.put("href", "url");
 
-      assertEquals("<tag className=\"class\" attribute=\"attributeValue\">Value</tag>", result);
+      final var result = HTMLFactory.tag("tag", "class", "Value", attributes);
+
+      assertEquals("<tag className=\"class\" attribute=\"attributeValue\" href=\"url\">Value</tag>",
+          result);
     }
 
     @Test

--- a/app/src/test/java/se/inera/intyg/minaintyg/util/html/HTMLTextFactoryTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/util/html/HTMLTextFactoryTest.java
@@ -18,7 +18,7 @@ class HTMLTextFactoryTest {
   void shouldReturnLink() {
     final var result = HTMLTextFactory.link("url", "value");
 
-    assertEquals("<IDSLink href=\"url\">value</IDSLink>", result);
+    assertEquals("<a href=\"url\" target=\"_blank\">value</a>", result);
   }
 
   @Nested

--- a/app/src/test/java/se/inera/intyg/minaintyg/util/html/HTMLTextFactoryTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/util/html/HTMLTextFactoryTest.java
@@ -14,6 +14,13 @@ class HTMLTextFactoryTest {
     assertEquals("<p>title</p>", result);
   }
 
+  @Test
+  void shouldReturnLink() {
+    final var result = HTMLTextFactory.link("url", "value");
+
+    assertEquals("<IDSLink href=\"url\">value</IDSLink>", result);
+  }
+
   @Nested
   class Headings {
 

--- a/integration-api/src/main/java/se/inera/intyg/minaintyg/integration/api/certificate/GetCertificateIntegrationResponse.java
+++ b/integration-api/src/main/java/se/inera/intyg/minaintyg/integration/api/certificate/GetCertificateIntegrationResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Value;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.Certificate;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateText;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.common.AvailableFunction;
 
 @Value
@@ -12,4 +13,5 @@ public class GetCertificateIntegrationResponse {
 
   Certificate certificate;
   List<AvailableFunction> availableFunctions;
+  List<CertificateText> texts;
 }

--- a/integration-api/src/main/java/se/inera/intyg/minaintyg/integration/api/certificate/model/CertificateLink.java
+++ b/integration-api/src/main/java/se/inera/intyg/minaintyg/integration/api/certificate/model/CertificateLink.java
@@ -1,0 +1,13 @@
+package se.inera.intyg.minaintyg.integration.api.certificate.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class CertificateLink {
+
+  String id;
+  String name;
+  String url;
+}

--- a/integration-api/src/main/java/se/inera/intyg/minaintyg/integration/api/certificate/model/CertificateText.java
+++ b/integration-api/src/main/java/se/inera/intyg/minaintyg/integration/api/certificate/model/CertificateText.java
@@ -1,0 +1,16 @@
+package se.inera.intyg.minaintyg.integration.api.certificate.model;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.common.CertificateTextType;
+
+@Value
+@Builder
+public class CertificateText {
+
+  String text;
+  CertificateTextType type;
+  List<CertificateLink> links;
+
+}

--- a/integration-api/src/main/java/se/inera/intyg/minaintyg/integration/api/certificate/model/common/CertificateTextType.java
+++ b/integration-api/src/main/java/se/inera/intyg/minaintyg/integration/api/certificate/model/common/CertificateTextType.java
@@ -1,0 +1,5 @@
+package se.inera.intyg.minaintyg.integration.api.certificate.model.common;
+
+public enum CertificateTextType {
+  DESCRIPTION
+}

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/WebcertCertificateIntegrationService.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/WebcertCertificateIntegrationService.java
@@ -11,6 +11,7 @@ import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateRespon
 import se.inera.intyg.minaintyg.integration.webcert.converter.availablefunction.AvailableFunctionConverter;
 import se.inera.intyg.minaintyg.integration.webcert.converter.data.CertificateDataConverter;
 import se.inera.intyg.minaintyg.integration.webcert.converter.metadata.MetadataConverter;
+import se.inera.intyg.minaintyg.integration.webcert.converter.text.CertificateTextConverter;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +21,7 @@ public class WebcertCertificateIntegrationService implements GetCertificateInteg
   private final MetadataConverter metadataConverter;
   private final CertificateDataConverter certificateDataConverter;
   private final AvailableFunctionConverter availableFunctionConverter;
+  private final CertificateTextConverter certificateTextConverter;
 
   @Override
   public GetCertificateIntegrationResponse get(GetCertificateIntegrationRequest request) {
@@ -46,6 +48,11 @@ public class WebcertCertificateIntegrationService implements GetCertificateInteg
         )
         .availableFunctions(
             availableFunctionConverter.convert(response.getAvailableFunctions())
+        )
+        .texts(
+            response.getTexts().stream()
+                .map(certificateTextConverter::convert)
+                .toList()
         )
         .build();
   }

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/WebcertCertificateIntegrationService.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/WebcertCertificateIntegrationService.java
@@ -1,11 +1,14 @@
 package se.inera.intyg.minaintyg.integration.webcert;
 
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import se.inera.intyg.minaintyg.integration.api.certificate.GetCertificateIntegrationRequest;
 import se.inera.intyg.minaintyg.integration.api.certificate.GetCertificateIntegrationResponse;
 import se.inera.intyg.minaintyg.integration.api.certificate.GetCertificateIntegrationService;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.Certificate;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateText;
 import se.inera.intyg.minaintyg.integration.webcert.client.GetCertificateFromWebcertService;
 import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateResponseDTO;
 import se.inera.intyg.minaintyg.integration.webcert.converter.availablefunction.AvailableFunctionConverter;
@@ -49,14 +52,16 @@ public class WebcertCertificateIntegrationService implements GetCertificateInteg
         .availableFunctions(
             availableFunctionConverter.convert(response.getAvailableFunctions())
         )
-        .texts(
-            response.getTexts().stream()
-                .map(certificateTextConverter::convert)
-                .toList()
-        )
+        .texts(getTexts(response))
         .build();
   }
 
+  private List<CertificateText> getTexts(CertificateResponseDTO response) {
+    return response.getTexts() == null ? Collections.emptyList() :
+        response.getTexts().stream()
+            .map(certificateTextConverter::convert)
+            .toList();
+  }
 
   private static boolean validateResponse(CertificateResponseDTO response) {
     return response.getCertificate() == null || response.getCertificate().getData() == null

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/client/dto/CertificateLinkDTO.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/client/dto/CertificateLinkDTO.java
@@ -1,9 +1,13 @@
 package se.inera.intyg.minaintyg.integration.webcert.client.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Value
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class CertificateLinkDTO {
 

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/client/dto/CertificateLinkDTO.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/client/dto/CertificateLinkDTO.java
@@ -1,0 +1,13 @@
+package se.inera.intyg.minaintyg.integration.webcert.client.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class CertificateLinkDTO {
+
+  String id;
+  String name;
+  String url;
+}

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/client/dto/CertificateResponseDTO.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/client/dto/CertificateResponseDTO.java
@@ -14,4 +14,5 @@ public class CertificateResponseDTO {
 
   private CertificateDTO certificate;
   private List<AvailableFunctionDTO> availableFunctions;
+  private List<CertificateTextDTO> texts;
 }

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/client/dto/CertificateTextDTO.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/client/dto/CertificateTextDTO.java
@@ -1,11 +1,15 @@
 package se.inera.intyg.minaintyg.integration.webcert.client.dto;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.common.CertificateTextType;
 
-@Value
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class CertificateTextDTO {
 

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/client/dto/CertificateTextDTO.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/client/dto/CertificateTextDTO.java
@@ -1,0 +1,16 @@
+package se.inera.intyg.minaintyg.integration.webcert.client.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.common.CertificateTextType;
+
+@Value
+@Builder
+public class CertificateTextDTO {
+
+  String text;
+  CertificateTextType type;
+  List<CertificateLinkDTO> links;
+
+}

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateLinkConverter.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateLinkConverter.java
@@ -1,0 +1,17 @@
+package se.inera.intyg.minaintyg.integration.webcert.converter.text;
+
+import org.springframework.stereotype.Component;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateLink;
+import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateLinkDTO;
+
+@Component
+public class CertificateLinkConverter {
+
+  public CertificateLink convert(CertificateLinkDTO link) {
+    return CertificateLink.builder()
+        .id(link.getId())
+        .name(link.getName())
+        .url(link.getUrl())
+        .build();
+  }
+}

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateTextConverter.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateTextConverter.java
@@ -1,0 +1,25 @@
+package se.inera.intyg.minaintyg.integration.webcert.converter.text;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateText;
+import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateTextDTO;
+
+@Component
+@RequiredArgsConstructor
+public class CertificateTextConverter {
+
+  private final CertificateLinkConverter certificateLinkConverter;
+
+  public CertificateText convert(CertificateTextDTO text) {
+    return CertificateText.builder()
+        .text(text.getText())
+        .type(text.getType())
+        .links(
+            text.getLinks().stream()
+                .map(certificateLinkConverter::convert)
+                .toList()
+        )
+        .build();
+  }
+}

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateTextConverter.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateTextConverter.java
@@ -1,7 +1,10 @@
 package se.inera.intyg.minaintyg.integration.webcert.converter.text;
 
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateLink;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateText;
 import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateTextDTO;
 
@@ -16,10 +19,15 @@ public class CertificateTextConverter {
         .text(text.getText())
         .type(text.getType())
         .links(
-            text.getLinks().stream()
-                .map(certificateLinkConverter::convert)
-                .toList()
+            convertLinks(text)
         )
         .build();
+  }
+
+  private List<CertificateLink> convertLinks(CertificateTextDTO text) {
+    return text.getLinks() == null ? Collections.emptyList()
+        : text.getLinks().stream()
+            .map(certificateLinkConverter::convert)
+            .toList();
   }
 }

--- a/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateTextConverter.java
+++ b/integration-webcert/src/main/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateTextConverter.java
@@ -14,12 +14,12 @@ public class CertificateTextConverter {
 
   private final CertificateLinkConverter certificateLinkConverter;
 
-  public CertificateText convert(CertificateTextDTO text) {
+  public CertificateText convert(CertificateTextDTO certificateText) {
     return CertificateText.builder()
-        .text(text.getText())
-        .type(text.getType())
+        .text(certificateText.getText())
+        .type(certificateText.getType())
         .links(
-            convertLinks(text)
+            convertLinks(certificateText)
         )
         .build();
   }

--- a/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/WebcertCertificateIntegrationServiceTest.java
+++ b/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/WebcertCertificateIntegrationServiceTest.java
@@ -249,4 +249,31 @@ class WebcertCertificateIntegrationServiceTest {
     assertEquals(expectedCertificateText, result.getTexts().get(0));
     assertEquals(expectedCertificateText, result.getTexts().get(1));
   }
+
+  @Test
+  void shouldReturnResponseWithNoTexts() {
+    final var expectedCertificateText = Collections.emptyList();
+
+    final var response = CertificateResponseDTO.builder()
+        .certificate(
+            CertificateDTO.builder()
+                .data(
+                    Map.of(ID, CertificateDataElement.builder().build())
+                )
+                .metadata(
+                    CertificateMetadataDTO.builder()
+                        .id(ID)
+                        .name(NAME)
+                        .build()
+                )
+                .build()
+        )
+        .build();
+
+    when(getCertificateFromWebcertService.get(REQUEST)).thenReturn(response);
+
+    final var result = webcertCertificateIntegrationService.get(REQUEST);
+
+    assertEquals(expectedCertificateText, result.getTexts());
+  }
 }

--- a/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/WebcertCertificateIntegrationServiceTest.java
+++ b/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/WebcertCertificateIntegrationServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import se.inera.intyg.minaintyg.integration.api.certificate.GetCertificateIntegrationRequest;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateCategory;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateMetadata;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateText;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.common.AvailableFunction;
 import se.inera.intyg.minaintyg.integration.api.certificate.model.common.CertificateType;
 import se.inera.intyg.minaintyg.integration.webcert.client.GetCertificateFromWebcertService;
@@ -24,9 +26,11 @@ import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateDTO;
 import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateDataElement;
 import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateMetadataDTO;
 import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateResponseDTO;
+import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateTextDTO;
 import se.inera.intyg.minaintyg.integration.webcert.converter.availablefunction.AvailableFunctionConverter;
 import se.inera.intyg.minaintyg.integration.webcert.converter.data.CertificateDataConverter;
 import se.inera.intyg.minaintyg.integration.webcert.converter.metadata.MetadataConverter;
+import se.inera.intyg.minaintyg.integration.webcert.converter.text.CertificateTextConverter;
 
 @ExtendWith(MockitoExtension.class)
 class WebcertCertificateIntegrationServiceTest {
@@ -48,6 +52,9 @@ class WebcertCertificateIntegrationServiceTest {
 
   @Mock
   private AvailableFunctionConverter availableFunctionConverter;
+
+  @Mock
+  private CertificateTextConverter certificateTextConverter;
 
   @InjectMocks
   private WebcertCertificateIntegrationService webcertCertificateIntegrationService;
@@ -108,6 +115,7 @@ class WebcertCertificateIntegrationServiceTest {
                 )
                 .build()
         )
+        .texts(Collections.emptyList())
         .build();
     final var expectedResult = List.of(
         CertificateCategory.builder().build()
@@ -142,6 +150,7 @@ class WebcertCertificateIntegrationServiceTest {
                 )
                 .build()
         )
+        .texts(Collections.emptyList())
         .build();
 
     final var expectedMetadata = CertificateMetadata.builder()
@@ -192,6 +201,7 @@ class WebcertCertificateIntegrationServiceTest {
                 AvailableFunctionDTO.builder().build()
             )
         )
+        .texts(Collections.emptyList())
         .build();
 
     when(getCertificateFromWebcertService.get(REQUEST)).thenReturn(response);
@@ -201,5 +211,42 @@ class WebcertCertificateIntegrationServiceTest {
     final var result = webcertCertificateIntegrationService.get(REQUEST);
 
     assertEquals(expectedAvailableFunctions, result.getAvailableFunctions());
+  }
+
+  @Test
+  void shouldReturnResponseWithTexts() {
+    final var expectedCertificateText = CertificateText.builder().build();
+
+    final var response = CertificateResponseDTO.builder()
+        .certificate(
+            CertificateDTO.builder()
+                .data(
+                    Map.of(ID, CertificateDataElement.builder().build())
+                )
+                .metadata(
+                    CertificateMetadataDTO.builder()
+                        .id(ID)
+                        .name(NAME)
+                        .build()
+                )
+                .build()
+        )
+        .texts(
+            List.of(
+                CertificateTextDTO.builder().build(),
+                CertificateTextDTO.builder().build()
+            )
+        )
+        .build();
+
+    when(getCertificateFromWebcertService.get(REQUEST)).thenReturn(response);
+    when(certificateTextConverter.convert(any(CertificateTextDTO.class)))
+        .thenReturn(expectedCertificateText);
+
+    final var result = webcertCertificateIntegrationService.get(REQUEST);
+
+    assertEquals(2, result.getTexts().size());
+    assertEquals(expectedCertificateText, result.getTexts().get(0));
+    assertEquals(expectedCertificateText, result.getTexts().get(1));
   }
 }

--- a/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateLinkConverterTest.java
+++ b/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateLinkConverterTest.java
@@ -1,0 +1,44 @@
+package se.inera.intyg.minaintyg.integration.webcert.converter.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateLinkDTO;
+
+@ExtendWith(MockitoExtension.class)
+class CertificateLinkConverterTest {
+
+  private static final CertificateLinkDTO link = CertificateLinkDTO
+      .builder()
+      .url("URL")
+      .id("ID")
+      .name("NAME")
+      .build();
+
+  @InjectMocks
+  CertificateLinkConverter certificateLinkConverter;
+
+  @Test
+  void shouldConvertId() {
+    final var response = certificateLinkConverter.convert(link);
+
+    assertEquals(link.getId(), response.getId());
+  }
+
+  @Test
+  void shouldConvertName() {
+    final var response = certificateLinkConverter.convert(link);
+
+    assertEquals(link.getName(), response.getName());
+  }
+
+  @Test
+  void shouldConvertUrl() {
+    final var response = certificateLinkConverter.convert(link);
+
+    assertEquals(link.getUrl(), response.getUrl());
+  }
+}

--- a/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateTextConverterTest.java
+++ b/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateTextConverterTest.java
@@ -4,8 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -40,43 +42,60 @@ class CertificateTextConverterTest {
       .links(List.of(linkDTO, linkDTO))
       .build();
 
+  private static final CertificateTextDTO certificateTextNoLinks = CertificateTextDTO
+      .builder()
+      .text("TEXT")
+      .type(CertificateTextType.DESCRIPTION)
+      .build();
+
   @Mock
   CertificateLinkConverter certificateLinkConverter;
 
   @InjectMocks
   CertificateTextConverter certificateTextConverter;
 
-  @BeforeEach
-  void setup() {
-    when(certificateLinkConverter.convert(any(CertificateLinkDTO.class)))
-        .thenReturn(link);
+  @Nested
+  class HasLinks {
+
+    @BeforeEach
+    void setup() {
+      when(certificateLinkConverter.convert(any(CertificateLinkDTO.class)))
+          .thenReturn(link);
+    }
+
+    @Test
+    void shouldConvertText() {
+      final var response = certificateTextConverter.convert(certificateText);
+
+      assertEquals(certificateText.getText(), response.getText());
+    }
+
+    @Test
+    void shouldConvertType() {
+      final var response = certificateTextConverter.convert(certificateText);
+
+      assertEquals(certificateText.getType(), response.getType());
+    }
+
+    @Test
+    void shouldConvertLink() {
+      final var response = certificateTextConverter.convert(certificateText);
+
+      assertEquals(link, response.getLinks().get(0));
+    }
+
+    @Test
+    void shouldConvertLinks() {
+      final var response = certificateTextConverter.convert(certificateText);
+
+      assertEquals(2, response.getLinks().size());
+    }
   }
 
   @Test
-  void shouldConvertText() {
-    final var response = certificateTextConverter.convert(certificateText);
+  void shouldConvertNullLinks() {
+    final var response = certificateTextConverter.convert(certificateTextNoLinks);
 
-    assertEquals(certificateText.getText(), response.getText());
-  }
-
-  @Test
-  void shouldConvertType() {
-    final var response = certificateTextConverter.convert(certificateText);
-
-    assertEquals(certificateText.getType(), response.getType());
-  }
-
-  @Test
-  void shouldConvertLink() {
-    final var response = certificateTextConverter.convert(certificateText);
-
-    assertEquals(link, response.getLinks().get(0));
-  }
-
-  @Test
-  void shouldConvertLinks() {
-    final var response = certificateTextConverter.convert(certificateText);
-
-    assertEquals(2, response.getLinks().size());
+    assertEquals(Collections.emptyList(), response.getLinks());
   }
 }

--- a/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateTextConverterTest.java
+++ b/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/converter/text/CertificateTextConverterTest.java
@@ -1,0 +1,82 @@
+package se.inera.intyg.minaintyg.integration.webcert.converter.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.CertificateLink;
+import se.inera.intyg.minaintyg.integration.api.certificate.model.common.CertificateTextType;
+import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateLinkDTO;
+import se.inera.intyg.minaintyg.integration.webcert.client.dto.CertificateTextDTO;
+
+@ExtendWith(MockitoExtension.class)
+class CertificateTextConverterTest {
+
+  private static final CertificateLinkDTO linkDTO = CertificateLinkDTO
+      .builder()
+      .url("URL")
+      .id("ID")
+      .name("NAME")
+      .build();
+
+  private static final CertificateLink link = CertificateLink
+      .builder()
+      .url("URL")
+      .id("ID")
+      .name("NAME")
+      .build();
+
+  private static final CertificateTextDTO certificateText = CertificateTextDTO
+      .builder()
+      .text("TEXT")
+      .type(CertificateTextType.DESCRIPTION)
+      .links(List.of(linkDTO, linkDTO))
+      .build();
+
+  @Mock
+  CertificateLinkConverter certificateLinkConverter;
+
+  @InjectMocks
+  CertificateTextConverter certificateTextConverter;
+
+  @BeforeEach
+  void setup() {
+    when(certificateLinkConverter.convert(any(CertificateLinkDTO.class)))
+        .thenReturn(link);
+  }
+
+  @Test
+  void shouldConvertText() {
+    final var response = certificateTextConverter.convert(certificateText);
+
+    assertEquals(certificateText.getText(), response.getText());
+  }
+
+  @Test
+  void shouldConvertType() {
+    final var response = certificateTextConverter.convert(certificateText);
+
+    assertEquals(certificateText.getType(), response.getType());
+  }
+
+  @Test
+  void shouldConvertLink() {
+    final var response = certificateTextConverter.convert(certificateText);
+
+    assertEquals(link, response.getLinks().get(0));
+  }
+
+  @Test
+  void shouldConvertLinks() {
+    final var response = certificateTextConverter.convert(certificateText);
+
+    assertEquals(2, response.getLinks().size());
+  }
+}


### PR DESCRIPTION
Flyttat ut länkinformationen som ett objekt för att underlätta om man ska formatera samma länk flera gånger i samma text, och för att kunna utnyttja find/replace-funktioner i Java. Om vi istället lägger länkinformationen i texten så måste vi hitta informationen, plocka ut den och formatera om den och sedan placera tillbaka den. 