### PR TITLE
K1J-1999: Resolve SonarQube issues after Java 25 upgrade

### DIFF
--- a/app/src/main/java/se/inera/intyg/minaintyg/auth/Saml2AuthenticationToken.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/auth/Saml2AuthenticationToken.java
@@ -24,11 +24,11 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2A
 
 public class Saml2AuthenticationToken extends AbstractAuthenticationToken {
 
-  private final Object principal;
+  private final MinaIntygUser principal;
   private final Saml2Authentication saml2Authentication;
   private final String name;
 
-  public Saml2AuthenticationToken(Object principal, Saml2Authentication authentication) {
+  public Saml2AuthenticationToken(MinaIntygUser principal, Saml2Authentication authentication) {
     super(authentication.getAuthorities());
     this.principal = principal;
     this.saml2Authentication = authentication;

--- a/app/src/main/java/se/inera/intyg/minaintyg/certificate/CertificateController.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/certificate/CertificateController.java
@@ -98,7 +98,9 @@ public class CertificateController {
   @GetMapping(value = "/{certificateId}/pdf/{fileName}", produces = "application/pdf")
   @PerformanceLogging(eventAction = "print-certificate", eventType = EVENT_TYPE_ACCESSED)
   public ResponseEntity<byte[]> printCertificate(
-      @PathVariable String certificateId, @RequestParam(required = false) String customizationId) {
+      @PathVariable String certificateId,
+      @PathVariable String fileName,
+      @RequestParam(required = false) String customizationId) {
 
     final var response =
         printCertificateService.print(
@@ -107,14 +109,14 @@ public class CertificateController {
                 .customizationId(customizationId)
                 .build());
 
-    final var responseHeaders = getHttpHeaders();
+    final var responseHeaders = getHttpHeaders(fileName);
 
     return ResponseEntity.ok().headers(responseHeaders).body(response.getPdfData());
   }
 
-  private static HttpHeaders getHttpHeaders() {
+  private static HttpHeaders getHttpHeaders(String fileName) {
     final var responseHeaders = new HttpHeaders();
-    responseHeaders.set(CONTENT_DISPOSITION, INLINE);
+    responseHeaders.set(CONTENT_DISPOSITION, INLINE + "; filename=\"" + fileName + "\"");
     return responseHeaders;
   }
 }

--- a/app/src/main/java/se/inera/intyg/minaintyg/config/WebSecurityConfig.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/config/WebSecurityConfig.java
@@ -184,7 +184,7 @@ public class WebSecurityConfig {
     return http.build();
   }
 
-  private void configureTestability(HttpSecurity http) throws Exception {
+  private void configureTestability(HttpSecurity http) {
     http.authorizeHttpRequests(request -> request.requestMatchers(TESTABILITY_API).permitAll())
         .csrf(csrfConfigurer -> csrfConfigurer.ignoringRequestMatchers(TESTABILITY_API));
   }

--- a/app/src/main/java/se/inera/intyg/minaintyg/exception/CitizenInactiveException.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/exception/CitizenInactiveException.java
@@ -23,7 +23,7 @@ import se.inera.intyg.minaintyg.auth.LoginMethod;
 
 public class CitizenInactiveException extends AuthenticationException {
 
-  private LoginMethod loginMethod;
+  private final LoginMethod loginMethod;
 
   public CitizenInactiveException(String message, LoginMethod loginMethod) {
     super(message);

--- a/app/src/main/java/se/inera/intyg/minaintyg/exception/LoginAgeLimitException.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/exception/LoginAgeLimitException.java
@@ -23,7 +23,7 @@ import se.inera.intyg.minaintyg.auth.LoginMethod;
 
 public class LoginAgeLimitException extends AuthenticationException {
 
-  private LoginMethod loginMethod;
+  private final LoginMethod loginMethod;
 
   public LoginAgeLimitException(String message, LoginMethod loginMethod) {
     super(message);

--- a/app/src/main/java/se/inera/intyg/minaintyg/logging/service/MonitoringLogService.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/logging/service/MonitoringLogService.java
@@ -40,7 +40,7 @@ public class MonitoringLogService {
 
   public void logUserLogin(String personId, String loginMethod) {
     final var hashedPersonId = hashUtility.hash(personId);
-    try (MdcCloseableMap ignored =
+    try (MdcCloseableMap _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CITIZEN_LOGIN))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_INFO)
@@ -52,7 +52,7 @@ public class MonitoringLogService {
   }
 
   public void logUserLoginFailed(String exceptionMessage, String loginMethod) {
-    try (MdcCloseableMap ignored =
+    try (MdcCloseableMap _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CITIZEN_LOGIN_FAILURE))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_INFO)
@@ -64,7 +64,7 @@ public class MonitoringLogService {
 
   public void logUserLogout(String personId, String loginMethod) {
     final var hashedPersonId = hashUtility.hash(personId);
-    try (MdcCloseableMap ignored =
+    try (MdcCloseableMap _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CITIZEN_LOGOUT))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_INFO)
@@ -76,7 +76,7 @@ public class MonitoringLogService {
   }
 
   public void logListCertificates(String personId, int nbrOfCertificates) {
-    try (MdcCloseableMap ignored =
+    try (MdcCloseableMap _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.LIST_CERTIFICATES))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_ACCESSED)
@@ -86,7 +86,7 @@ public class MonitoringLogService {
   }
 
   public void logCertificateRead(String certificateId, String type) {
-    try (MdcCloseableMap ignored =
+    try (MdcCloseableMap _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CERTIFICATE_READ))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_ACCESSED)
@@ -98,7 +98,7 @@ public class MonitoringLogService {
   }
 
   public void logCertificateSent(String certificateId, String type, String recipient) {
-    try (MdcCloseableMap ignored =
+    try (MdcCloseableMap _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CERTIFICATE_SEND))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_CHANGE)
@@ -120,7 +120,7 @@ public class MonitoringLogService {
   }
 
   private void logCertificatePrintedFully(String certificateId, String certificateType) {
-    try (MdcCloseableMap ignored =
+    try (MdcCloseableMap _ =
         MdcCloseableMap.builder()
             .put(
                 MdcLogConstants.EVENT_ACTION,
@@ -134,7 +134,7 @@ public class MonitoringLogService {
   }
 
   private void logCertificatePrintedEmployeeCopy(String certificateId, String certificateType) {
-    try (MdcCloseableMap ignored =
+    try (MdcCloseableMap _ =
         MdcCloseableMap.builder()
             .put(
                 MdcLogConstants.EVENT_ACTION,
@@ -149,7 +149,7 @@ public class MonitoringLogService {
 
   public void logClientError(String id, String code, String message, String stackTrace) {
     final var stackTraceText = Strings.isNullOrEmpty(stackTrace) ? NO_STACK_TRACE : stackTrace;
-    try (MdcCloseableMap ignored =
+    try (MdcCloseableMap _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CLIENT_ERROR))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_INFO)
@@ -163,7 +163,7 @@ public class MonitoringLogService {
   }
 
   public void logIllegalCertificateAccess(String message) {
-    try (MdcCloseableMap ignored =
+    try (MdcCloseableMap _ =
         MdcCloseableMap.builder()
             .put(
                 MdcLogConstants.EVENT_ACTION,

--- a/app/src/main/java/se/inera/intyg/minaintyg/logging/service/MonitoringLogService.java
+++ b/app/src/main/java/se/inera/intyg/minaintyg/logging/service/MonitoringLogService.java
@@ -40,7 +40,7 @@ public class MonitoringLogService {
 
   public void logUserLogin(String personId, String loginMethod) {
     final var hashedPersonId = hashUtility.hash(personId);
-    try (MdcCloseableMap _ =
+    try (var _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CITIZEN_LOGIN))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_INFO)
@@ -52,7 +52,7 @@ public class MonitoringLogService {
   }
 
   public void logUserLoginFailed(String exceptionMessage, String loginMethod) {
-    try (MdcCloseableMap _ =
+    try (var _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CITIZEN_LOGIN_FAILURE))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_INFO)
@@ -64,7 +64,7 @@ public class MonitoringLogService {
 
   public void logUserLogout(String personId, String loginMethod) {
     final var hashedPersonId = hashUtility.hash(personId);
-    try (MdcCloseableMap _ =
+    try (var _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CITIZEN_LOGOUT))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_INFO)
@@ -76,7 +76,7 @@ public class MonitoringLogService {
   }
 
   public void logListCertificates(String personId, int nbrOfCertificates) {
-    try (MdcCloseableMap _ =
+    try (var _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.LIST_CERTIFICATES))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_ACCESSED)
@@ -86,7 +86,7 @@ public class MonitoringLogService {
   }
 
   public void logCertificateRead(String certificateId, String type) {
-    try (MdcCloseableMap _ =
+    try (var _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CERTIFICATE_READ))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_ACCESSED)
@@ -98,7 +98,7 @@ public class MonitoringLogService {
   }
 
   public void logCertificateSent(String certificateId, String type, String recipient) {
-    try (MdcCloseableMap _ =
+    try (var _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CERTIFICATE_SEND))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_CHANGE)
@@ -120,7 +120,7 @@ public class MonitoringLogService {
   }
 
   private void logCertificatePrintedFully(String certificateId, String certificateType) {
-    try (MdcCloseableMap _ =
+    try (var _ =
         MdcCloseableMap.builder()
             .put(
                 MdcLogConstants.EVENT_ACTION,
@@ -134,7 +134,7 @@ public class MonitoringLogService {
   }
 
   private void logCertificatePrintedEmployeeCopy(String certificateId, String certificateType) {
-    try (MdcCloseableMap _ =
+    try (var _ =
         MdcCloseableMap.builder()
             .put(
                 MdcLogConstants.EVENT_ACTION,
@@ -149,7 +149,7 @@ public class MonitoringLogService {
 
   public void logClientError(String id, String code, String message, String stackTrace) {
     final var stackTraceText = Strings.isNullOrEmpty(stackTrace) ? NO_STACK_TRACE : stackTrace;
-    try (MdcCloseableMap _ =
+    try (var _ =
         MdcCloseableMap.builder()
             .put(MdcLogConstants.EVENT_ACTION, toEventType(MonitoringEvent.CLIENT_ERROR))
             .put(MdcLogConstants.EVENT_TYPE, MdcLogConstants.EVENT_TYPE_INFO)
@@ -163,7 +163,7 @@ public class MonitoringLogService {
   }
 
   public void logIllegalCertificateAccess(String message) {
-    try (MdcCloseableMap _ =
+    try (var _ =
         MdcCloseableMap.builder()
             .put(
                 MdcLogConstants.EVENT_ACTION,

--- a/app/src/test/java/se/inera/intyg/minaintyg/auth/AuthenticationEventListenerTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/auth/AuthenticationEventListenerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -34,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.event.InteractiveAuthenticationSuccessEvent;
 import org.springframework.security.authentication.event.LogoutSuccessEvent;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
 import se.inera.intyg.minaintyg.logging.service.MonitoringLogService;
 
@@ -86,10 +88,10 @@ class AuthenticationEventListenerTest {
 
     @Test
     void shallNotLogAnythingIfPrincipalIsNotOfCorrectType() {
+      final var authentication = mock(Authentication.class);
+      when(authentication.getPrincipal()).thenReturn("wrong-principal");
       interactiveAuthenticationSuccessEvent =
-          new InteractiveAuthenticationSuccessEvent(
-              new Saml2AuthenticationToken(new Object(), mock(Saml2Authentication.class)),
-              this.getClass());
+          new InteractiveAuthenticationSuccessEvent(authentication, this.getClass());
 
       authenticationEventListener.onLoginSuccess(interactiveAuthenticationSuccessEvent);
 
@@ -135,9 +137,9 @@ class AuthenticationEventListenerTest {
 
     @Test
     void shallNotLogAnythingIfPrincipalIsNotOfCorrectType() {
-      logoutSuccessEvent =
-          new LogoutSuccessEvent(
-              new Saml2AuthenticationToken(new Object(), mock(Saml2Authentication.class)));
+      final var authentication = mock(Authentication.class);
+      when(authentication.getPrincipal()).thenReturn("wrong-principal");
+      logoutSuccessEvent = new LogoutSuccessEvent(authentication);
 
       authenticationEventListener.onLogoutSuccess(logoutSuccessEvent);
 

--- a/app/src/test/java/se/inera/intyg/minaintyg/auth/SessionTimeoutFilterTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/auth/SessionTimeoutFilterTest.java
@@ -27,7 +27,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -44,9 +43,6 @@ class SessionTimeoutFilterTest {
 
   @Mock SessionTimeoutService sessionTimeoutService;
   @InjectMocks SessionTimeoutFilter filter;
-
-  @BeforeEach
-  void setup() {}
 
   @Test
   void shouldCallServiceWithRequest() throws ServletException, IOException {

--- a/app/src/test/java/se/inera/intyg/minaintyg/auth/SessionTimeoutServiceTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/auth/SessionTimeoutServiceTest.java
@@ -128,13 +128,6 @@ class SessionTimeoutServiceTest {
 
       assertTrue(session.isInvalid());
     }
-
-    @Test
-    void shouldInvalidateSessionIfExpiredExcludedURL() {
-      sessionTimeoutService.checkSessionValidity(request);
-
-      assertTrue(session.isInvalid());
-    }
   }
 
   @Nested
@@ -179,23 +172,7 @@ class SessionTimeoutServiceTest {
     }
 
     @Test
-    void shouldNotResetLastAccessedTimeIfUrlContainsExcludedUrl() {
-      ReflectionTestUtils.setField(sessionTimeoutService, "excludedUrls", EXCLUDED_ACTUAL_URLS);
-
-      sessionTimeoutService.checkSessionValidity(request);
-
-      assertEquals(LAST_ACCESS_TIME, session.getAttribute(LAST_ACCESS_ATTRIBUTE));
-    }
-
-    @Test
     void shouldNotInvalidateSessionIfNotExpiredIncludedURL() {
-      sessionTimeoutService.checkSessionValidity(request);
-
-      assertFalse(session.isInvalid());
-    }
-
-    @Test
-    void shouldNotInvalidateSessionIfNotExpiredExcludedURL() {
       sessionTimeoutService.checkSessionValidity(request);
 
       assertFalse(session.isInvalid());

--- a/app/src/test/java/se/inera/intyg/minaintyg/certificate/CertificateControllerTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/certificate/CertificateControllerTest.java
@@ -69,6 +69,7 @@ class CertificateControllerTest {
       List.of(CertificateListItem.builder().build());
 
   private static final String CUSTOMIZATION_ID = "C_ID";
+  private static final String PDF_FILE_NAME = "PRINT";
   private static final PrintCertificateRequestDTO PRINT_REQUEST =
       PrintCertificateRequestDTO.builder().customizationId(CUSTOMIZATION_ID).build();
 
@@ -248,7 +249,7 @@ class CertificateControllerTest {
 
     @Test
     void shouldUseCertificateIdInRequest() {
-      certificateController.printCertificate(CERTIFICATE_ID, CUSTOMIZATION_ID);
+      certificateController.printCertificate(CERTIFICATE_ID, PDF_FILE_NAME, CUSTOMIZATION_ID);
       final var captor = ArgumentCaptor.forClass(PrintCertificateRequest.class);
 
       verify(printCertificateService).print(captor.capture());
@@ -257,7 +258,7 @@ class CertificateControllerTest {
 
     @Test
     void shouldUseCustomizationIdInRequest() {
-      certificateController.printCertificate(CERTIFICATE_ID, CUSTOMIZATION_ID);
+      certificateController.printCertificate(CERTIFICATE_ID, PDF_FILE_NAME, CUSTOMIZATION_ID);
       final var captor = ArgumentCaptor.forClass(PrintCertificateRequest.class);
 
       verify(printCertificateService).print(captor.capture());
@@ -277,7 +278,7 @@ class CertificateControllerTest {
       @Test
       void shouldReturnPdfDataReturnedFromServiceInBody() {
         final var response =
-            certificateController.printCertificate(CERTIFICATE_ID, CUSTOMIZATION_ID);
+            certificateController.printCertificate(CERTIFICATE_ID, PDF_FILE_NAME, CUSTOMIZATION_ID);
 
         assertEquals(PRINT_RESPONSE.getPdfData(), response.getBody());
       }
@@ -302,14 +303,17 @@ class CertificateControllerTest {
 
     @Test
     void shouldReturnConvertedFilenameReturnedFromServiceAsHeader() {
-      final var response = certificateController.printCertificate(CERTIFICATE_ID, CUSTOMIZATION_ID);
+      final var response =
+          certificateController.printCertificate(CERTIFICATE_ID, PDF_FILE_NAME, CUSTOMIZATION_ID);
 
-      assertEquals(List.of("inline"), response.getHeaders().get(CONTENT_DISPOSITION));
+      assertEquals(
+          List.of("inline; filename=\"PRINT\""), response.getHeaders().get(CONTENT_DISPOSITION));
     }
 
     @Test
     void shouldReturnPdfDataReturnedFromServiceInBody() {
-      final var response = certificateController.printCertificate(CERTIFICATE_ID, CUSTOMIZATION_ID);
+      final var response =
+          certificateController.printCertificate(CERTIFICATE_ID, PDF_FILE_NAME, CUSTOMIZATION_ID);
 
       assertEquals(PRINT_RESPONSE.getPdfData(), response.getBody());
     }

--- a/app/src/test/java/se/inera/intyg/minaintyg/filter/FilterControllerTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/filter/FilterControllerTest.java
@@ -41,7 +41,7 @@ class FilterControllerTest {
   @Mock GetCertificateListFilterService getCertificateListFilterService;
 
   @InjectMocks FilterController filterController;
-  private final GetCertificateFilterResponse EXPECTED_RESPONSE =
+  private final GetCertificateFilterResponse expectedResponse =
       GetCertificateFilterResponse.builder()
           .statuses(List.of(CertificateStatusType.SENT))
           .years(List.of("2020"))
@@ -52,7 +52,7 @@ class FilterControllerTest {
 
   @BeforeEach
   void setup() {
-    when(getCertificateListFilterService.get()).thenReturn(EXPECTED_RESPONSE);
+    when(getCertificateListFilterService.get()).thenReturn(expectedResponse);
   }
 
   @Nested
@@ -62,35 +62,35 @@ class FilterControllerTest {
     void shouldSetCertificateTypes() {
       final var response = filterController.getCertificateListFilter();
 
-      assertEquals(EXPECTED_RESPONSE.getCertificateTypes(), response.getCertificateTypes());
+      assertEquals(expectedResponse.getCertificateTypes(), response.getCertificateTypes());
     }
 
     @Test
     void shouldSetYears() {
       final var response = filterController.getCertificateListFilter();
 
-      assertEquals(EXPECTED_RESPONSE.getYears(), response.getYears());
+      assertEquals(expectedResponse.getYears(), response.getYears());
     }
 
     @Test
     void shouldSetUnits() {
       final var response = filterController.getCertificateListFilter();
 
-      assertEquals(EXPECTED_RESPONSE.getUnits(), response.getUnits());
+      assertEquals(expectedResponse.getUnits(), response.getUnits());
     }
 
     @Test
     void shouldSetStatuses() {
       final var response = filterController.getCertificateListFilter();
 
-      assertEquals(EXPECTED_RESPONSE.getStatuses(), response.getStatuses());
+      assertEquals(expectedResponse.getStatuses(), response.getStatuses());
     }
 
     @Test
     void shouldSetTotal() {
       final var response = filterController.getCertificateListFilter();
 
-      assertEquals(EXPECTED_RESPONSE.getTotal(), response.getTotal());
+      assertEquals(expectedResponse.getTotal(), response.getTotal());
     }
   }
 }

--- a/app/src/test/java/se/inera/intyg/minaintyg/util/html/HTMLFactoryTest.java
+++ b/app/src/test/java/se/inera/intyg/minaintyg/util/html/HTMLFactoryTest.java
@@ -86,13 +86,6 @@ class HTMLFactoryTest {
   }
 
   @Test
-  void shouldConvertSpecialCharactersIfNotParent() {
-    final var result = HTMLFactory.tag("p", "Value<Value");
-
-    assertEquals("<p>Value&lt;Value</p>", result);
-  }
-
-  @Test
   void shouldNotConvertSpecialCharactersIfParent() {
     final var result = HTMLFactory.tagWithChildren("p", "Value<p>Value</p> test");
 
@@ -144,13 +137,6 @@ class HTMLFactoryTest {
 
     @Test
     void shouldConvertSpecialCharactersAsDefault() {
-      final var result = HTMLFactory.tag("p", "class", "Value<Value");
-
-      assertEquals("<p className=\"class\">Value&lt;Value</p>", result);
-    }
-
-    @Test
-    void shouldConvertSpecialCharactersIfNotParent() {
       final var result = HTMLFactory.tag("p", "class", "Value<Value");
 
       assertEquals("<p className=\"class\">Value&lt;Value</p>", result);

--- a/integration-intygsadmin/src/test/java/se/inera/intyg/minaintyg/integration/intygsadmin/BannerConverterTest.java
+++ b/integration-intygsadmin/src/test/java/se/inera/intyg/minaintyg/integration/intygsadmin/BannerConverterTest.java
@@ -44,12 +44,6 @@ class BannerConverterTest {
   private static final ApplicationDTO MINA_INTYG = ApplicationDTO.MINA_INTYG;
   private static final LocalDateTime NOW = LocalDateTime.now();
   private static final String MESSAGE = "message";
-  private static final BannerPriorityDTO BANNER_DTO_PRIORITY_LAG = BannerPriorityDTO.LAG;
-  private static final BannerPriorityDTO BANNER_DTO_PRIORITY_MEDEL = BannerPriorityDTO.MEDEL;
-  private static final BannerPriorityDTO BANNER_DTO_PRIORITY_HÖG = BannerPriorityDTO.HOG;
-  private static final BannerPriority BANNER_PRIORITY_LOW = BannerPriority.LOW;
-  private static final BannerPriority BANNER_PRIORITY_MEDIUM = BannerPriority.MEDIUM;
-  private static final BannerPriority BANNER_PRIORITY_HIGH = BannerPriority.HIGH;
   private static final LocalDateTime DISPLAY_TO = LocalDateTime.now().plusDays(5);
 
   private List<BannerDTO> getBannerDTOS(BannerPriorityDTO priority) {

--- a/integration-intygstjanst/src/test/java/se/inera/intyg/minaintyg/integration/intygstjanst/CertificateStatusServiceTest.java
+++ b/integration-intygstjanst/src/test/java/se/inera/intyg/minaintyg/integration/intygstjanst/CertificateStatusServiceTest.java
@@ -107,13 +107,6 @@ class CertificateStatusServiceTest {
   }
 
   @Test
-  void shouldNotIncludeStatusIfRelationsIsEmpty() {
-    final var response = certificateStatusService.get(Collections.emptyList(), null, null);
-
-    assertEquals(0, response.size());
-  }
-
-  @Test
   void shouldOnlyIncludeReplacedIfCertificateIsBothSentAndReplaced() {
     final var response = certificateStatusService.get(REPLACED_RELATIONS, SENT_RECIPIENT, null);
 

--- a/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/converter/data/value/MedicalInvestigationValueConverterTest.java
+++ b/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/converter/data/value/MedicalInvestigationValueConverterTest.java
@@ -346,12 +346,12 @@ class MedicalInvestigationValueConverterTest {
   }
 
   private static CertificateDataValueMedicalInvestigation createMedicalInvestigationValue(
-      String INVESTIGATION_TYPE_ID_ONE, String dateOne, String INFORMATION_SOURCE_ONE) {
+      String investigationTypeCode, String dateOne, String informationSource) {
     return CertificateDataValueMedicalInvestigation.builder()
         .investigationType(
             CertificateDataValueCode.builder()
                 .id(INVESTIGATION_TYPE_ID)
-                .code(INVESTIGATION_TYPE_ID_ONE)
+                .code(investigationTypeCode)
                 .build())
         .date(
             CertificateDataValueDate.builder()
@@ -361,7 +361,7 @@ class MedicalInvestigationValueConverterTest {
         .informationSource(
             CertificateDataValueText.builder()
                 .id(INFORMATION_SOURCE_ID)
-                .text(INFORMATION_SOURCE_ONE)
+                .text(informationSource)
                 .build())
         .build();
   }

--- a/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/converter/data/value/VisualAcuitiesValueConverterTest.java
+++ b/integration-webcert/src/test/java/se/inera/intyg/minaintyg/integration/webcert/converter/data/value/VisualAcuitiesValueConverterTest.java
@@ -284,50 +284,6 @@ class VisualAcuitiesValueConverterTest {
   }
 
   @Test
-  void shallReturnConsiderNullContactLensesAsFalse() {
-
-    final var expectedValue =
-        CertificateQuestionValueGeneralTable.builder()
-            .headings(
-                List.of(
-                    getDataElement(""),
-                    getHeadingElement(WITHOUT_CORRECTION_LABEL),
-                    getHeadingElement(WITH_CORRECTION_LABEL),
-                    getHeadingElement(CONTACT_LENSES_LABEL)))
-            .values(
-                List.of(
-                    List.of(
-                        getHeadingElement(RIGHT_EYE_LABEL),
-                        getDataElement("0,1"),
-                        getDataElement("-"),
-                        getDataElement("Nej")),
-                    List.of(
-                        getHeadingElement(LEFT_EYE_LABEL),
-                        getDataElement("1,1"),
-                        getDataElement("-"),
-                        getDataElement("Nej")),
-                    List.of(
-                        getHeadingElement(BINOCULAR_LABEL),
-                        getDataElement("-"),
-                        getDataElement("-"),
-                        getDataElement("-"))))
-            .build();
-
-    final var element =
-        CertificateDataElement.builder()
-            .config(createVisualAcuityConfiguration(true))
-            .value(
-                CertificateDataValueVisualAcuities.builder()
-                    .rightEye(createVisualActuityValue("0,1", null, null))
-                    .leftEye(createVisualActuityValue("1,1", null, null))
-                    .build())
-            .build();
-
-    final var actualValue = visualAcuitiesValueConverter.convert(element);
-    assertEquals(expectedValue, actualValue);
-  }
-
-  @Test
   void shallExcludeContactLensesColumnAndRows() {
     final var expectedValue =
         CertificateQuestionValueGeneralTable.builder()

--- a/logging/build.gradle
+++ b/logging/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
 
     implementation "ch.qos.logback:logback-classic"
     implementation "com.google.guava:guava"

--- a/logging/src/main/java/se/inera/intyg/minaintyg/logging/MdcServletFilter.java
+++ b/logging/src/main/java/se/inera/intyg/minaintyg/logging/MdcServletFilter.java
@@ -22,42 +22,33 @@ import static se.inera.intyg.minaintyg.logging.MdcLogConstants.SESSION_ID_KEY;
 import static se.inera.intyg.minaintyg.logging.MdcLogConstants.SPAN_ID_KEY;
 import static se.inera.intyg.minaintyg.logging.MdcLogConstants.TRACE_ID_KEY;
 
-import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.support.SpringBeanAutowiringSupport;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
-public class MdcServletFilter implements Filter {
+@RequiredArgsConstructor
+public class MdcServletFilter extends OncePerRequestFilter {
 
-  @Autowired private MdcHelper mdcHelper;
+  private final MdcHelper mdcHelper;
 
   @Override
-  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-      throws IOException, ServletException {
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
     try {
-      if (request instanceof HttpServletRequest http) {
-        MDC.put(SESSION_ID_KEY, mdcHelper.sessionId(http));
-        MDC.put(TRACE_ID_KEY, mdcHelper.traceId(http));
-        MDC.put(SPAN_ID_KEY, mdcHelper.spanId());
-      }
-      chain.doFilter(request, response);
+      MDC.put(SESSION_ID_KEY, mdcHelper.sessionId(request));
+      MDC.put(TRACE_ID_KEY, mdcHelper.traceId(request));
+      MDC.put(SPAN_ID_KEY, mdcHelper.spanId());
+      filterChain.doFilter(request, response);
     } finally {
       MDC.clear();
     }
-  }
-
-  @Override
-  public void init(FilterConfig filterConfig) {
-    SpringBeanAutowiringSupport.processInjectionBasedOnServletContext(
-        this, filterConfig.getServletContext());
   }
 }

--- a/logging/src/main/java/se/inera/intyg/minaintyg/logging/PerformanceLoggingAdvice.java
+++ b/logging/src/main/java/se/inera/intyg/minaintyg/logging/PerformanceLoggingAdvice.java
@@ -47,7 +47,7 @@ public class PerformanceLoggingAdvice {
         final var duration = Duration.between(start, end).toMillis();
         final var className = joinPoint.getSignature().getDeclaringTypeName();
         final var methodName = joinPoint.getSignature().getName();
-        try (final var mdcLogConstants =
+        try (final var _ =
             MdcCloseableMap.builder()
                 .put(MdcLogConstants.EVENT_START, start.toString())
                 .put(MdcLogConstants.EVENT_END, end.toString())


### PR DESCRIPTION
Fix Java 25 try-with-resources warnings, use constructor injection in MdcServletFilter,
bind PDF filename path variable, and clean up duplicate/unused test code.